### PR TITLE
Fix MySQL pool not closing on shutdown

### DIFF
--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -2,12 +2,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable prettier/prettier */
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import * as mysql from 'mysql2/promise';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
-export class DatabaseService {
+export class DatabaseService implements OnModuleDestroy {
     private pool;
 
     constructor(private config: ConfigService){
@@ -18,6 +18,10 @@ export class DatabaseService {
             password: this.config.get('DB_PASSWORD'),
             database: this.config.get('DB_NAME')
         }) 
+    }
+
+    async onModuleDestroy() {
+        await this.pool.end();
     }
 
     async query<T>(sql: string, params?: any[]): Promise<T> {


### PR DESCRIPTION
## Problem

DatabaseService creates a mysql2 connection pool in its constructor but never closes it, causing Railway to wait for open connections to drain before sending SIGTERM — resulting in a forced kill after ~90 seconds on every deploy or shutdown.

## Solution

Implemented the NestJS OnModuleDestroy lifecycle interface on DatabaseService and added an onModuleDestroy() method that calls await this.pool.end(). NestJS invokes this hook during graceful shutdown, ensuring all pooled connections are released before the process exits.

### Changes
- **Modified** `src/database/database.service.ts`

---
*Generated by [Railway](https://railway.com)*