### PR TITLE
Fix database connection and auth errors

### DIFF
--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -25,7 +25,11 @@ export class DatabaseService implements OnModuleDestroy {
 
         this.pool.on('connection', (connection) => {
             const tz = this.config.get('DB_TIMEZONE') ?? 'Europe/Sarajevo';
-            connection.query(`SET time_zone = '${tz}'`);
+            connection.query(`SET time_zone = '${tz}'`, (err) => {
+                if (err) {
+                    this.logger.error(`Failed to set timezone on connection: ${err.message}`);
+                }
+            });
         });
     }
 


### PR DESCRIPTION
## Problem

The `pool.on('connection')` event handler in `database.service.ts` called `connection.query()` without a callback or `await`, making the `SET time_zone` query fire-and-forget. Because the `connection` event is a synchronous Node.js event emitter callback (not an async context), the promise returned by `mysql2/promise`'s `query()` was never handled — errors were silently swallowed and the timezone was not reliably set before the connection was used, causing downstream query failures and 500 errors on the login and register endpoints.

## Solution

Changed `connection.query()` to use the callback form (`query(sql, (err) => { ... })`), which is the correct pattern inside a synchronous event handler. The callback now logs any timezone-setting failure via the existing `Logger` instance, making errors visible instead of silent.

### Changes
- **Modified** `src/database/database.service.ts`

---
*Generated by [Railway](https://railway.com)*