### PR TITLE
Fix session store initialization and error handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -140,17 +140,39 @@ app.use((req, res, next) => {
   );
 
   const MySQLStore = MySQLStoreFactory(session);
-  const sessionStore = new MySQLStore({
-    host: process.env.DB_HOST,
-    port: parseInt(process.env.DB_PORT ?? '3306', 10),
-    user: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    clearExpired: true,
-    checkExpirationInterval: 900000,
-    expiration: 1800000,
-    createDatabaseTable: true,
-  });
+
+  let sessionStore: InstanceType<typeof MySQLStore>;
+  try {
+    sessionStore = new MySQLStore({
+      host: process.env.DB_HOST,
+      port: parseInt(process.env.DB_PORT ?? '3306', 10),
+      user: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+      clearExpired: true,
+      checkExpirationInterval: 900000,
+      expiration: 1800000,
+      createDatabaseTable: true,
+    });
+
+    // Wait for the store to finish creating its sessions table before the app
+    // starts accepting requests. onReady() resolves once the table exists (or
+    // rejects if the connection / DDL statement fails).
+    await new Promise<void>((resolve, reject) => {
+      sessionStore.onReady().then(resolve).catch(reject);
+    });
+
+    console.log('[SessionStore] MySQL session store initialized successfully');
+
+    // Catch runtime errors (e.g. connection drops after startup) so they are
+    // visible in logs rather than swallowed silently.
+    (sessionStore as any).on('error', (err: Error) => {
+      console.error('[SessionStore] Runtime error:', err);
+    });
+  } catch (err) {
+    console.error('[SessionStore] Failed to initialize MySQL session store:', err);
+    process.exit(1);
+  }
 
   app.use(
     session({


### PR DESCRIPTION
## Problem

The `express-mysql-session` store was constructed synchronously with no error handling. Any failure during table creation or initial connection was silently swallowed, leaving the session middleware in a broken state and causing every login/register request to return a 500 error with no useful log output to diagnose the root cause.

## Solution

Wrapped the `MySQLStore` construction in a `try-catch` that logs the error and calls `process.exit(1)` on failure so the problem is immediately visible. Added `await sessionStore.onReady()` so the app does not start accepting requests until the sessions table is confirmed to exist. Added a runtime `error` event listener on the store to surface any post-startup connection errors in the logs.

### Changes
- **Modified** `src/main.ts`

---
*Generated by [Railway](https://railway.com)*