### PR TITLE
Fix session store initialization - remove onReady call

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -155,13 +155,6 @@ app.use((req, res, next) => {
       createDatabaseTable: true,
     });
 
-    // Wait for the store to finish creating its sessions table before the app
-    // starts accepting requests. onReady() resolves once the table exists (or
-    // rejects if the connection / DDL statement fails).
-    await new Promise<void>((resolve, reject) => {
-      sessionStore.onReady().then(resolve).catch(reject);
-    });
-
     console.log('[SessionStore] MySQL session store initialized successfully');
 
     // Catch runtime errors (e.g. connection drops after startup) so they are


### PR DESCRIPTION
## Problem

The app crashes on startup because `sessionStore.onReady()` is called in `src/main.ts`, but `express-mysql-session` does not expose an `onReady()` method. This causes an unhandled rejection that exits the process before the server can bind.

## Solution

Removed the `await new Promise` block that called `sessionStore.onReady()`. The try-catch around the `MySQLStore` constructor is kept for connection-error handling, and `createDatabaseTable: true` ensures the sessions table is created automatically on first use — no explicit readiness check is needed.

### Changes
- **Modified** `src/main.ts`

---
*Generated by [Railway](https://railway.com)*