### PR TITLE
Add comprehensive error logging for authentication

### DIFF
--- a/src/authentication/authentication.controller.ts
+++ b/src/authentication/authentication.controller.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable prettier/prettier */
-import { Controller, Post, Request, UseGuards, Get, Body, Query, BadRequestException } from '@nestjs/common';
+import { Controller, Post, Request, UseGuards, Get, Body, Query, BadRequestException, Logger, InternalServerErrorException } from '@nestjs/common';
 import { AuthenticationService } from './authentication.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
@@ -15,6 +15,8 @@ import { Throttle } from '@nestjs/throttler';
 @Controller('api/v1/auth')
 export class AuthenticationController {
 
+    private readonly logger = new Logger(AuthenticationController.name);
+
     constructor(private authService: AuthenticationService) {}
     
     @ApiOperation({ 'summary' : 'Prijavljivanje putem emaila i lozinke'})
@@ -22,18 +24,28 @@ export class AuthenticationController {
     @UseGuards(AuthGuard('local'))
     @Post('/login')
     async login(@Body() _loginDto: LoginDto, @Request() req){
-        await new Promise<void>((resolve, reject) => {
-            req.logIn(req.user, (error: unknown) => {
-                if (error) {
-                    reject(error instanceof Error ? error : new Error('Login failed'));
-                    return;
-                }
+        try {
+            await new Promise<void>((resolve, reject) => {
+                req.logIn(req.user, (error: unknown) => {
+                    if (error) {
+                        reject(error instanceof Error ? error : new Error('Login failed'));
+                        return;
+                    }
 
-                resolve();
+                    resolve();
+                });
             });
-        });
 
-        return req.user;
+            return req.user;
+        } catch (error) {
+            this.logger.error(
+                'Login failed during session establishment',
+                error instanceof Error ? error.stack : String(error),
+            );
+            throw error instanceof Error && (error as any).status
+                ? error
+                : new InternalServerErrorException('Login failed. Please try again.');
+        }
     }
 
     @ApiOperation({ 'summary' : 'Dohvatanje podataka o trenutno prijavljenom korisniku.'})
@@ -66,7 +78,15 @@ export class AuthenticationController {
     async register(@Body() body: RegisterDto) {
         const { email, password, fullName } = body;
 
-        return this.authService.register(email, password, fullName);
+        try {
+            return await this.authService.register(email, password, fullName);
+        } catch (error) {
+            this.logger.error(
+                `Registration failed for email: ${email}`,
+                error instanceof Error ? error.stack : String(error),
+            );
+            throw error;
+        }
     }
 
     @ApiOperation({ 'summary' : 'Verifikacija mail adrese nakon kreiranja naloga.'})

--- a/src/common/filters/global-exception.filters.ts
+++ b/src/common/filters/global-exception.filters.ts
@@ -3,10 +3,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable prettier/prettier */
 
-import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus} from "@nestjs/common";
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Logger} from "@nestjs/common";
 
 @Catch() // ← hvata SVE greške
 export class GlobalExceptionFilter implements ExceptionFilter {
+
+  private readonly logger = new Logger(GlobalExceptionFilter.name);
 
   catch(exception: unknown, host: ArgumentsHost) {
     // host je kontekst trenutnog zahtjeva
@@ -37,6 +39,17 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       } else {
         message = exception.message
       }
+    }
+
+    if (status >= 500) {
+      this.logger.error(
+        `Unhandled exception — HTTP ${status}: ${Array.isArray(message) ? message.join(', ') : message}`,
+        exception instanceof Error ? exception.stack : String(exception),
+      );
+    } else {
+      this.logger.warn(
+        `HTTP ${status}: ${Array.isArray(message) ? message.join(', ') : message}`,
+      );
     }
 
     if (response.headersSent) return;


### PR DESCRIPTION
## Problem

The global exception filter was catching all errors and returning 500 responses without logging anything, making it impossible to diagnose failures in the login and register endpoints. Errors were being silently swallowed with no stack trace or context in the logs.

## Solution

Added a NestJS `Logger` instance to `GlobalExceptionFilter` that logs 5xx errors at `error` level (with full stack trace) and 4xx errors at `warn` level before sending the response. In `AuthenticationController`, added a `Logger` and wrapped the `login` and `register` methods in try-catch blocks that log the full error stack before re-throwing, so failures at the session establishment and service layer are both captured.

### Changes
- **Modified** `src/common/filters/global-exception.filters.ts`
- **Modified** `src/authentication/authentication.controller.ts`

---
*Generated by [Railway](https://railway.com)*