### PR TITLE
Fix MySQL caching_sha2_password authentication properly

### DIFF
--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -24,7 +24,8 @@ export class DatabaseService implements OnModuleDestroy {
         supportBigNumbers: true,
         bigNumberStrings: true,
         authPlugins: {
-            caching_sha2_password: () => () => Buffer.alloc(0),
+            caching_sha2_password: ({ password }: { password: string }) =>
+                () => Buffer.from(`${password}\0`),
         },
         });
 


### PR DESCRIPTION
## Problem

The `authPlugins` handler for `caching_sha2_password` was returning `Buffer.alloc(0)` — an empty buffer — instead of the actual password. This caused MySQL to receive no credentials, producing both `ER_NOT_SUPPORTED_AUTH_MODE` and `Access denied for user 'root'@'...' (using password: NO)`.

## Solution

Updated the `caching_sha2_password` plugin in `database.service.ts` to destructure the `password` from the plugin context and return `Buffer.from(\`${password}\0\`)`. The mysql2 v3 auth plugin API passes connection credentials as the first argument to the outer factory function, and the inner function must return a Buffer containing the null-terminated password string for the handshake to succeed.

### Changes
- **Modified** `src/database/database.service.ts`

---
*Generated by [Railway](https://railway.com)*