### PR TITLE
Fix TypeScript error in authPlugins configuration

### DIFF
--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -24,8 +24,8 @@ export class DatabaseService implements OnModuleDestroy {
         supportBigNumbers: true,
         bigNumberStrings: true,
         authPlugins: {
-            caching_sha2_password: ({ password }: { password: string }) =>
-                () => Buffer.from(`${password}\0`),
+            caching_sha2_password: ({ connection }) =>
+                () => Buffer.from(`${connection.config.password ?? ''}\0`),
         },
         });
 


### PR DESCRIPTION
## Problem

The `caching_sha2_password` auth plugin handler in `database.service.ts` was typed as `({ password }: { password: string }) => ...`, but mysql2 v3's `AuthPlugin` type passes `{ connection, command }` to the plugin factory — not `password` directly. This caused a TypeScript compilation error: `Property 'password' is missing in type '{ connection: Connection; command: string; }'`.

## Solution

Updated the handler to destructure `{ connection }` from the plugin metadata (matching the `AuthPlugin` type in mysql2 v3) and read the password from `connection.config.password`. The null-byte-terminated buffer format for `caching_sha2_password` is preserved.

### Changes
- **Modified** `src/database/database.service.ts`

---
*Generated by [Railway](https://railway.com)*